### PR TITLE
Improvements to the Python wrapper

### DIFF
--- a/egs/python/egs/__init__.py
+++ b/egs/python/egs/__init__.py
@@ -187,15 +187,11 @@ class GLOffscreenRenderer(GLContext, ctypes.Structure):
         return _egs.egs_gloffscreen_get_data(self._gl_ctx_ref)
 
 
-def _empty_destructor(data_len, data, plugin_data):
-    pass
-
-
 class PluginWrapper(ctypes.Structure):
     _fields_ = [("plugin_name", ctypes.c_char_p), ("data_length", ctypes.c_size_t), ("data", ctypes.POINTER(ctypes.c_uint8))]
     apply_fun_callback = ctypes.CFUNCTYPE(None, ctypes.POINTER(GLContext), ctypes.c_size_t, ctypes.POINTER(ctypes.c_uint8), ctypes.c_void_p)
     terminate_fun_callback = ctypes.CFUNCTYPE(None, ctypes.c_size_t, ctypes.POINTER(ctypes.c_uint8), ctypes.c_void_p)
-    empty_terminate_fun = terminate_fun_callback(_empty_destructor)
+    empty_terminate_fun = terminate_fun_callback(lambda *args, **kwargs: None)
 
     def get_display_list_elem(self):
         return _egs.egs_c_wrapper_create(self)

--- a/egs/python/egs/__init__.py
+++ b/egs/python/egs/__init__.py
@@ -2,32 +2,26 @@ import ctypes
 import os
 import sys
 import importlib
-from sys import platform as _platform
 import warnings
 
 
 if not os.environ.get('EGS_PATH'):
     os.environ['EGS_PATH'] = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
-os.environ["DYLD_LIBRARY_PATH"] = os.environ.get('DYLD_LIBRARY_PATH', '') + ":" + os.path.abspath("../")
-os.environ["LD_LIBRARY_PATH"] = os.environ.get('LD_LIBRARY_PATH', '') + ":" + os.path.abspath("../")
-
-_plugins = os.listdir(os.path.join(os.environ['EGS_PATH'], 'plugins'))
-for plugin in _plugins:
-    plugin_path = os.path.join(os.environ['EGS_PATH'], 'plugins', plugin)
-    if os.path.isdir(plugin_path):
-        sys.path.append(plugin_path)
-
-LIB_SUFFIX = 'so'
-if _platform == "darwin":
+if sys.platform == 'darwin':
+    LIB_PATH_ENV_VAR = 'DYLD_LIBRARY_PATH'
     LIB_SUFFIX = 'dylib'
+else:
+    LIB_PATH_ENV_VAR = 'LD_LIBRARY_PATH'
+    LIB_SUFFIX = 'so'
 
-LIB_NAME = 'libegs.'+LIB_SUFFIX
+_lib_paths = os.environ.get(LIB_PATH_ENV_VAR, '').split(':')
+_lib_paths.append(os.path.abspath("../"))
+os.environ[LIB_PATH_ENV_VAR] = ':'.join(_lib_paths)
 
-_egs = ctypes.CDLL(os.path.join(os.environ.get('EGS_PATH'), LIB_NAME))
+_egs = ctypes.CDLL(os.path.join(os.environ.get('EGS_PATH'), 'libegs.' + LIB_SUFFIX))
 
-
-(DEBUG, WARNING, ERROR) = map(ctypes.c_uint, range(1, 4))
+DEBUG, WARNING, ERROR = (ctypes.c_uint for c in range(1, 4))
 
 
 def _py_loader_callback(ctx, path, plugin_name):

--- a/egs/python/egs/__init__.py
+++ b/egs/python/egs/__init__.py
@@ -210,41 +210,56 @@ class PluginWrapper(ctypes.Structure):
 _egs.egs_context_create.argtypes = []
 _egs.egs_context_create.restype = ctypes.POINTER(Context)
 _egs.egs_context_destroy.argtypes = [ctypes.POINTER(Context)]
+_egs.egs_context_destroy.restype = None
 _egs.egs_context_load_plugin.argtypes = [ctypes.POINTER(Context), ctypes.c_char_p]
+_egs.egs_context_load_plugin.restype = None
 
 _egs.egs_display_list_create.argtypes = []
 _egs.egs_display_list_create.restype = ctypes.POINTER(DisplayList)
 _egs.egs_display_list_add_element.argtypes = [ctypes.POINTER(DisplayList), ctypes.POINTER(DisplayListElem)]
+_egs.egs_display_list_add_element.restype = None
 _egs.egs_display_list_element_apply.argtypes = [ctypes.POINTER(DisplayListElem), ctypes.POINTER(GLContext)]
+_egs.egs_display_list_element_apply.restype = None
 _egs.egs_display_list_destroy.argtypes = [ctypes.POINTER(DisplayList)]
+_egs.egs_display_list_destroy.restype = None
 
 _egs.egs_glfw_context_create.argtypes = [ctypes.POINTER(Context)]
 _egs.egs_glfw_context_create.restype = ctypes.POINTER(GLFWContext)
 _egs.egs_glfw_context_destroy.argtypes = [ctypes.POINTER(GLFWContext)]
+_egs.egs_glfw_context_destroy.restype = None
 
 _egs.egs_glip_glfw_context_create.argtypes = [ctypes.POINTER(Context)]
 _egs.egs_glip_glfw_context_create.restype = ctypes.POINTER(GLIPGLFWContext)
 _egs.egs_glip_glfw_context_destroy.argtypes = [ctypes.POINTER(GLIPGLFWContext)]
+_egs.egs_glip_glfw_context_destroy.restype = None
 
 _egs.egs_gloffscreen_context_create.argtypes = [ctypes.POINTER(Context)]
 _egs.egs_gloffscreen_context_create.restype = ctypes.POINTER(GLOffscreenRenderer)
 _egs.egs_gloffscreen_context_destroy.argtypes = [ctypes.POINTER(GLOffscreenRenderer)]
+_egs.egs_gloffscreen_context_destroy.restype = None
 _egs.egs_gloffscreen_get_data.argtypes = []
 _egs.egs_gloffscreen_get_data.restype = ctypes.POINTER(ctypes.c_int)
 
 _egs.egs_c_wrapper_create.argtypes = [PluginWrapper]
 _egs.egs_c_wrapper_create.restype = ctypes.POINTER(DisplayListElem)
 _egs.egs_c_wrapper_register_c_plugin.argtypes = [ctypes.c_char_p, PluginWrapper.apply_fun_callback, PluginWrapper.terminate_fun_callback]
+_egs.egs_c_wrapper_register_c_plugin.restype = None
 
 _egs_py_loader_fun = ctypes.CFUNCTYPE(None, ctypes.POINTER(GLContext), ctypes.c_char_p, ctypes.c_char_p)
 _wrapped_loader_fun = _egs_py_loader_fun(py_loader_callback)
 _egs.egs_context_set_py_loader_fun.argtypes = [ctypes.POINTER(Context), _egs_py_loader_fun]
+_egs.egs_context_set_py_loader_fun.restype = None
 _egs.egs_context_rotate.argtypes = [ctypes.POINTER(Context), ctypes.c_float, ctypes.c_float, ctypes.c_float, ctypes.c_float]
+_egs.egs_context_rotate.restype = None
 _egs.egs_context_set_property.argtypes = [ctypes.POINTER(Context), ctypes.c_char_p, ctypes.c_void_p, ctypes.c_size_t]
+_egs.egs_context_set_property.restype = None
 _egs.egs_context_get_property.argtypes = [ctypes.POINTER(Context), ctypes.c_char_p, ctypes.c_void_p, ctypes.c_size_t]
 _egs.egs_context_get_property.restype = ctypes.c_void_p
 _egs.egs_context_register_py_plugin_function.argtypes = [ctypes.POINTER(Context), ctypes.c_char_p, ctypes.c_char_p, ctypes.c_void_p]
+_egs.egs_context_register_py_plugin_function.restype = None
 
 _egs.egs_gl_context_update.argtypes = [ctypes.POINTER(GLContext), ctypes.POINTER(DisplayList)]
+_egs.egs_gl_context_update.restype = ctypes.c_int
 
 _egs.egs_printf.argtypes = [ctypes.c_uint, ctypes.c_char_p]
+_egs.egs_printf.restype = None


### PR DESCRIPTION
This pull request provides various improvements to the EGS Python wrapper. Among other changes:

- ctypes wrapped functions now return either `None` or `ctypes.c_int` instead of falling back to the default restype (`ctypes.c_int`)
- Adding potential plugin paths to `sys.path` is unnecessary
- _egs_imported_modules is restricted to py_loader_callback