### PR TITLE
Added egs.plugins module

### DIFF
--- a/egs/plugins/rendertotexture_plugin/rendertotexture_plugin.py
+++ b/egs/plugins/rendertotexture_plugin/rendertotexture_plugin.py
@@ -1,15 +1,15 @@
 import ctypes
 import sys
 import os
-from egs import DisplayListElem, Context
+from egs import DisplayListElem, Context, LIB_SUFFIX
 
-_rendertotexture_plugin = ctypes.cdll.LoadLibrary(os.path.join(os.environ.get('EGS_PATH'), 'plugins/rendertotexture_plugin/', 'librendertotexture_plugin.so'))
+_rendertotexture_plugin = ctypes.cdll.LoadLibrary(os.path.join(os.environ.get('EGS_PATH'), 'plugins', 'rendertotexture_plugin', 'librendertotexture_plugin.'+LIB_SUFFIX))
 
 
 class Surface:
     def __init__(self, positions):
         flat_positions = [item for position in positions[:] for item in position]
-        self._rendertotexture_ref = _rendertotexture_plugin.rendertotexture_plugin_create_surface(
+        self._rendertotexture_ref = _rendertotexture_plugin.plot_plugin_create_surface(
             (ctypes.c_float * len(flat_positions))(*flat_positions))
 
     #def apply(self, ctx, data_ptr):
@@ -19,6 +19,6 @@ class Surface:
     def display_list_elem_ref(self):
         return self._rendertotexture_ref
 
-_rendertotexture_plugin.rendertotexture_plugin_create_surface.argtypes = [ctypes.POINTER(ctypes.c_float)]
-_rendertotexture_plugin.rendertotexture_plugin_create_surface.restype = ctypes.POINTER(DisplayListElem)
+_rendertotexture_plugin.plot_plugin_create_surface.argtypes = [ctypes.POINTER(ctypes.c_float)]
+_rendertotexture_plugin.plot_plugin_create_surface.restype = ctypes.POINTER(DisplayListElem)
 #_sphere_plugin.sphere_apply.argtypes = [ctypes.POINTER(Context), ctypes.c_size_t, ctypes.POINTER(ctypes.c_uint8), ctypes.c_void_p]

--- a/egs/python/egs/plugins.py
+++ b/egs/python/egs/plugins.py
@@ -1,0 +1,35 @@
+"""
+This module provides a unified way of importing EGS plugins.
+
+It will try importing all plugins it finds in the EGS_PATH and make these
+available for import via:
+import egs.plugins.<plugin_name>
+or:
+from egs.plugins.<plugin_name> import <object_name>
+"""
+
+import importlib
+import os
+import sys
+import warnings
+
+
+def _load_all_plugins():
+    base_plugin_path = os.path.abspath(os.path.join(os.environ['EGS_PATH'], 'plugins'))
+    for plugin_name in os.listdir(base_plugin_path):
+        if plugin_name.startswith('.'):
+            continue
+        plugin_path = os.path.join(base_plugin_path, plugin_name)
+        if not os.path.isdir(plugin_path):
+            continue
+        if not os.path.isfile(os.path.join(plugin_path, plugin_name + '.py')):
+            continue
+        sys.path.append(plugin_path)
+        try:
+            module = importlib.import_module(plugin_name)
+            sys.modules['egs.plugins.' + plugin_name] = module
+        except ImportError:
+            warnings.warn("Plugin {} could not be loaded!".format(plugin_name))
+        sys.path.remove(plugin_path)
+
+_load_all_plugins()

--- a/examples/molecule_example.py
+++ b/examples/molecule_example.py
@@ -1,5 +1,5 @@
 import egs
-from molecule_plugin import Molecule
+from egs.plugins.molecule_plugin import Molecule
 
 context = egs.Context()
 glfw_context = egs.GLIPGLFWContext(context)


### PR DESCRIPTION
This module imports all available plugins, so that the user can write:
import egs.plugins.molecule_plugin
or:
from egs.plugins.molecule_plugin import Molecule

This pull request also solves some problems with the rendertotexture_plugin, as loading this plugin raised exceptions and thereby blocked importing other plugins.